### PR TITLE
[FIX]:  Add a synchronization timeout 

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ To configure your application properly, here is a list of key to set:
 | `budgetInsight.url` | No | _string_ | Budget Insight sandbox URL |
 | `budgetInsight.clientId` | No | _string_ | Budget Insight Client ID for the sandbox |
 | `budgetInsight.clientSecret` | No | _string_ | Budget Insight Client secret for the sandbox |
+| `budgetInsight.synchronizationTimeout` | No | _number_ | Timeout after each the synchronization trial is cancelled |
 | `targetUrl` | No | _string_ | Target URL for your resthook. See [the documentation](https://developers.algoan.com/public/docs/algoan_documentation/resthooks_and_events/resthooks.html#managing-your-resthook) for more information |
 | `eventList` | No | _array<string>_ | Event List you want to subscribe to |
 | `restHooksSecret` | No | _string_ | Resthooks secrets ensuring that all calls are made by Algoan. See [the documentation](https://developers.algoan.com/public/docs/algoan_documentation/resthooks_and_events/resthooks.html#validating-resthook-events) for more information |

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ To configure your application properly, here is a list of key to set:
 | `budgetInsight.clientId` | No | _string_ | Budget Insight Client ID for the sandbox |
 | `budgetInsight.clientSecret` | No | _string_ | Budget Insight Client secret for the sandbox |
 | `budgetInsight.synchronizationTimeout` | No | _number_ | Timeout in seconds after each the synchronization trial is cancelled |
+| `budgetInsight.waitingTime` | No | _number_ | Time in seconds to wait between each call to get items |
 | `targetUrl` | No | _string_ | Target URL for your resthook. See [the documentation](https://developers.algoan.com/public/docs/algoan_documentation/resthooks_and_events/resthooks.html#managing-your-resthook) for more information |
 | `eventList` | No | _array<string>_ | Event List you want to subscribe to |
 | `restHooksSecret` | No | _string_ | Resthooks secrets ensuring that all calls are made by Algoan. See [the documentation](https://developers.algoan.com/public/docs/algoan_documentation/resthooks_and_events/resthooks.html#validating-resthook-events) for more information |

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ To configure your application properly, here is a list of key to set:
 | `budgetInsight.url` | No | _string_ | Budget Insight sandbox URL |
 | `budgetInsight.clientId` | No | _string_ | Budget Insight Client ID for the sandbox |
 | `budgetInsight.clientSecret` | No | _string_ | Budget Insight Client secret for the sandbox |
-| `budgetInsight.synchronizationTimeout` | No | _number_ | Timeout after each the synchronization trial is cancelled |
+| `budgetInsight.synchronizationTimeout` | No | _number_ | Timeout in seconds after each the synchronization trial is cancelled |
 | `targetUrl` | No | _string_ | Target URL for your resthook. See [the documentation](https://developers.algoan.com/public/docs/algoan_documentation/resthooks_and_events/resthooks.html#managing-your-resthook) for more information |
 | `eventList` | No | _array<string>_ | Event List you want to subscribe to |
 | `restHooksSecret` | No | _string_ | Resthooks secrets ensuring that all calls are made by Algoan. See [the documentation](https://developers.algoan.com/public/docs/algoan_documentation/resthooks_and_events/resthooks.html#validating-resthook-events) for more information |

--- a/config/default.json
+++ b/config/default.json
@@ -8,7 +8,8 @@
     "url": "http://localhost:4000/",
     "clientId": "budgetInsightClientId",
     "clientSecret": "budgetInsightClientSecret",
-    "synchronizationTimeout": 1200
+    "synchronizationTimeout": 1200,
+    "waitingTime": 5000
   },
   "targetUrl": "http://localhost:8080/hooks",
   "eventList": [

--- a/config/default.json
+++ b/config/default.json
@@ -7,7 +7,8 @@
   "budgetInsight": {
     "url": "http://localhost:4000/",
     "clientId": "budgetInsightClientId",
-    "clientSecret": "budgetInsightClientSecret"
+    "clientSecret": "budgetInsightClientSecret",
+    "synchronizationTimeout": 1200
   },
   "targetUrl": "http://localhost:8080/hooks",
   "eventList": [

--- a/config/env/test.json
+++ b/config/env/test.json
@@ -7,7 +7,8 @@
   "budgetInsight": {
     "url": "http://localhost:4000/",
     "clientId": "budgetInsightClientId",
-    "clientSecret": "budgetInsightClientSecret"
+    "clientSecret": "budgetInsightClientSecret",
+    "waitingTime": 0
   },
   "targetUrl": "https://test",
   "eventList": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -6032,6 +6032,11 @@
         }
       }
     },
+    "delay": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-4.4.0.tgz",
+      "integrity": "sha512-txgOrJu3OdtOfTiEOT2e76dJVfG/1dz2NZ4F0Pyt4UGZJryssMRp5vdM5wQoLwSOBNdrJv3F9PAhp/heqd7vrA=="
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "nestjs-connector-boilerplate",
+  "name": "@algoan/nestjs-budget-insight-connector",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "hbs": "^4.1.1",
     "js-yaml": "^3.14.0",
     "lodash": "^4.17.15",
+    "moment": "^2.27.0",
     "moment-timezone": "^0.5.31",
     "mongoose": "^5.9.20",
     "nest-winston": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "axios": "^0.19.2",
     "class-transformer": "^0.2.3",
     "class-validator": "^0.12.2",
+    "delay": "^4.4.0",
     "hbs": "^4.1.1",
     "js-yaml": "^3.14.0",
     "lodash": "^4.17.15",

--- a/src/hooks/services/hooks.service.ts
+++ b/src/hooks/services/hooks.service.ts
@@ -156,7 +156,7 @@ export class HooksService {
      * 2. Fetch user active connections
      */
     let synchronizationCompleted = false;
-    const timeout = moment().add(config.budgetInsight.synchronizationTimeout as number, 'seconds');
+    const timeout = moment().add(config.budgetInsight.synchronizationTimeout, 'seconds');
     while (!synchronizationCompleted && moment().isBefore(timeout)) {
       const connections: Connection[] = await this.aggregator.getConnections(
         permanentToken,
@@ -169,6 +169,16 @@ export class HooksService {
           synchronizationCompleted = false;
         }
       }
+    }
+
+    if (!synchronizationCompleted) {
+      const err = new Error('Synchronization failed');
+      this.logger.warn({
+        message: 'Synchronization failed after a timeout',
+        banksUserId: banksUser.id,
+        timeout: config.budgetInsight.synchronizationTimeout,
+      });
+      throw err;
     }
 
     /**

--- a/src/hooks/services/hooks.service.ts
+++ b/src/hooks/services/hooks.service.ts
@@ -14,6 +14,7 @@ import { UnauthorizedException, Injectable, NotFoundException, Logger } from '@n
 import { config } from 'node-config-ts';
 
 import * as moment from 'moment';
+import * as delay from 'delay';
 import { AlgoanService } from '../../algoan/algoan.service';
 import { EventDTO } from '../dto/event.dto';
 
@@ -32,6 +33,9 @@ import { BankreaderLinkRequiredDTO } from '../dto/bandreader-link-required.dto';
 import { BankreaderConfigurationRequiredDTO } from '../dto/bankreader-configuration-required.dto';
 import { BankreaderRequiredDTO } from '../dto/bankreader-required.dto';
 import { ClientConfig } from '../../aggregator/services/budget-insight/budget-insight.client';
+
+const WAITING_TIME: number = config.budgetInsight.waitingTime;
+
 /**
  * Hook service
  */
@@ -167,6 +171,8 @@ export class HooksService {
         // eslint-disable-next-line no-null/no-null
         if (connection.state !== null || connection.last_update === null) {
           synchronizationCompleted = false;
+          // Wait 5 seconds between each call
+          await delay(WAITING_TIME);
         }
       }
     }

--- a/src/hooks/services/hooks.service.ts
+++ b/src/hooks/services/hooks.service.ts
@@ -13,6 +13,7 @@ import {
 import { UnauthorizedException, Injectable, NotFoundException, Logger } from '@nestjs/common';
 import { config } from 'node-config-ts';
 
+import * as moment from 'moment';
 import { AlgoanService } from '../../algoan/algoan.service';
 import { EventDTO } from '../dto/event.dto';
 
@@ -155,7 +156,8 @@ export class HooksService {
      * 2. Fetch user active connections
      */
     let synchronizationCompleted = false;
-    while (!synchronizationCompleted) {
+    const timeout = moment().add(config.budgetInsight.synchronizationTimeout as number, 'seconds');
+    while (!synchronizationCompleted && moment().isBefore(timeout)) {
       const connections: Connection[] = await this.aggregator.getConnections(
         permanentToken,
         serviceAccount.config as ClientConfig,


### PR DESCRIPTION
## [FIX]:  Add a synchronization timeout 
### Description
Add a timeout for the synchronization to avoid infinite loop in case the aggregation is failing.
The timeout is set to 20 minutes by default and can be configured through `config.budgetInsight.synchronizationTimeout`