### PR TITLE
fix(budget-insight): get the connector name instead of bank

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs}/**/*.ts\" --fix",
-    "test": "jest",
+    "test": "USER=test jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",

--- a/src/aggregator/interfaces/budget-insight.interface.ts
+++ b/src/aggregator/interfaces/budget-insight.interface.ts
@@ -33,9 +33,9 @@ export interface Connection {
   last_update: string | null;
   state: ConnectionErrorState | null;
   active: boolean;
-  bank?: Bank;
   created: Date | null;
   next_try: Date | null;
+  connector?: Bank;
 }
 
 /**

--- a/src/aggregator/services/budget-insight/budget-insight.client.spec.ts
+++ b/src/aggregator/services/budget-insight/budget-insight.client.spec.ts
@@ -105,7 +105,7 @@ describe('BudgetInsightClient', () => {
     const actualResponse = await service.fetchConnection(token);
     expect(actualResponse).toEqual([makeConnection(0), makeConnection(2)]);
 
-    expect(spy).toHaveBeenCalledWith('http://localhost:4000//users/me/connections', {
+    expect(spy).toHaveBeenCalledWith('http://localhost:4000//users/me/connections?expand=connector', {
       headers: {
         ...headers.headers,
         Authorization: `Bearer ${token}`,

--- a/src/aggregator/services/budget-insight/budget-insight.client.ts
+++ b/src/aggregator/services/budget-insight/budget-insight.client.ts
@@ -94,7 +94,7 @@ export class BudgetInsightClient {
    */
   public async fetchConnection(permanentToken: string, clientConfig?: ClientConfig): Promise<Connection[]> {
     const baseUrl: string = this.getClientConfig(clientConfig).baseUrl;
-    const url: string = `${baseUrl}/users/me/connections`;
+    const url: string = `${baseUrl}/users/me/connections?expand=connector`;
     const resp: AxiosResponse<ConnectionWrapper> = await this.httpService
       .get(url, this.setHeaders(permanentToken))
       .toPromise();

--- a/src/aggregator/services/budget-insight/budget-insight.utils.spec.ts
+++ b/src/aggregator/services/budget-insight/budget-insight.utils.spec.ts
@@ -29,7 +29,7 @@ describe('BudgetInsightUtils', () => {
         last_update: '',
         state: null,
         active: true,
-        bank: {
+        connector: {
           name: 'bank-name',
         },
         created: new Date(),

--- a/src/aggregator/services/budget-insight/budget-insight.utils.ts
+++ b/src/aggregator/services/budget-insight/budget-insight.utils.ts
@@ -29,7 +29,7 @@ export const mapBudgetInsightAccount = (
   accounts.map((acc: BudgetInsightAccount) => {
     const connection: Connection | undefined = connections.find((con) => con.id === acc.id_connection);
 
-    return fromBIToAlgoanAccounts(acc, connection?.bank?.name);
+    return fromBIToAlgoanAccounts(acc, connection?.connector?.name);
   });
 
 /**


### PR DESCRIPTION
### Description

- Replace the bank property by `connector` to access to the bank name