### PR TITLE
[FEAT] Add refresh by handling userId

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17850,7 +17850,6 @@
         "init-package-json": "^1.10.3",
         "is-cidr": "^3.0.0",
         "json-parse-better-errors": "^1.0.2",
-        "JSONStream": "^1.3.5",
         "lazy-property": "~1.0.0",
         "libcipm": "^4.0.8",
         "libnpm": "^3.0.1",
@@ -27458,9 +27457,9 @@
       "integrity": "sha512-efPu9s/P+LZiqOH/vHswrYGJA355BW7zHJKKDaLfr+dwrTniydOB6GGgmI3BAijsH19ZqqRrcjDO0C9quLRItA=="
     },
     "@algoan/rest": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@algoan/rest/-/rest-2.3.0.tgz",
-      "integrity": "sha512-q5D6jgEcpwCAaXW3Vrsw1vEjf36fsXdF4wrW6x2hlRhL0yT2pV1B7AkLb4JwhzuaCVr7L9YejiJxDCOhXgHVJA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@algoan/rest/-/rest-2.3.1.tgz",
+      "integrity": "sha512-MzqpSH4fnXvU8JQM019UT3eGY0jeTSALHOnNI9CLD7mYvmoeyAPLD28p4WD4SgDxDsmwVcgr+I3xZhj0zNNItA==",
       "requires": {
         "axios": "^0.21.1",
         "form-data": "^4.0.0",
@@ -31748,6 +31747,16 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      }
+    },
     "abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -33936,8 +33945,8 @@
       "integrity": "sha512-RSo5S0WIwXZiRxUGTPuYFbqvrR4vpJ1BDdTlthFgvHt5kEdnd1+pdvwWphWn57/oIl4V72NMmOocFqqJ8mFFhA==",
       "dev": true,
       "requires": {
-        "is-text-path": "^1.0.1",
         "JSONStream": "^1.0.4",
+        "is-text-path": "^1.0.1",
         "lodash": "^4.17.15",
         "meow": "^7.0.0",
         "split2": "^2.0.0",
@@ -36033,9 +36042,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
-      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -40036,16 +40045,6 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
-    "JSONStream": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "dev": true,
-      "requires": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
-      }
-    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -41617,6 +41616,7 @@
       "integrity": "sha512-1Zh7LjuIoEhIyjkBflSSGzfjuPQwDlghNloppjruOH5bmj9midT9qcNT0tRUZRR04shU9ekrxNy9+UTBrqeBpQ==",
       "dev": true,
       "requires": {
+        "JSONStream": "^1.3.5",
         "abbrev": "~1.1.1",
         "ansicolors": "~0.3.2",
         "ansistyles": "~0.1.3",
@@ -41742,6 +41742,15 @@
         "write-file-atomic": "^2.4.3"
       },
       "dependencies": {
+        "JSONStream": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
+          }
+        },
         "abbrev": {
           "version": "1.1.1",
           "bundled": true,
@@ -43186,15 +43195,6 @@
           "bundled": true,
           "dev": true
         },
-        "JSONStream": {
-          "version": "1.3.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "jsonparse": "^1.2.0",
-            "through": ">=2.2.7 <3"
-          }
-        },
         "jsprim": {
           "version": "1.4.1",
           "bundled": true,
@@ -43802,9 +43802,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
+            "JSONStream": "^1.3.4",
             "bluebird": "^3.5.1",
             "figgy-pudding": "^3.4.1",
-            "JSONStream": "^1.3.4",
             "lru-cache": "^5.1.1",
             "make-fetch-happen": "^5.0.0",
             "npm-package-arg": "^6.1.0",
@@ -43881,6 +43881,8 @@
         },
         "opener": {
           "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+          "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
           "dev": true
         },
         "os-homedir": {
@@ -44580,21 +44582,6 @@
           "bundled": true,
           "dev": true
         },
-        "string_decoder": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.2.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
         "string-width": {
           "version": "2.1.1",
           "bundled": true,
@@ -44621,6 +44608,21 @@
               "requires": {
                 "ansi-regex": "^3.0.0"
               }
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.2.0",
+              "bundled": true,
+              "dev": true
             }
           }
         },
@@ -47423,11 +47425,6 @@
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-argv": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
@@ -47519,6 +47516,11 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringify-object": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@algoan/nestjs-http-exception-filter": "^1.0.8",
     "@algoan/nestjs-logging-interceptor": "^2.1.6",
-    "@algoan/rest": "^2.3.0",
+    "@algoan/rest": "^2.3.1",
     "@nestjs/common": "^7.6.13",
     "@nestjs/core": "^7.6.13",
     "@nestjs/platform-express": "^7.6.13",

--- a/src/aggregator/interfaces/budget-insight.interface.ts
+++ b/src/aggregator/interfaces/budget-insight.interface.ts
@@ -246,3 +246,24 @@ export interface BudgetInsightOwner {
     postal_address?: { full_address?: string | null };
   };
 }
+
+/**
+ * Response of the route Create an anonymous user
+ * https://docs.budget-insight.com/reference/authentication#create-an-anonymous-user
+ */
+export interface AnonymousUser {
+  auth_token: string;
+  type: string;
+  id_user: number;
+  expires_in: number | null;
+}
+
+/**
+ * Response of the route Get a user
+ * https://docs.budget-insight.com/reference/users#get-a-user
+ */
+export interface User {
+  id: number;
+  signin: Date | string;
+  platform: string;
+}

--- a/src/aggregator/services/aggregator.service.spec.ts
+++ b/src/aggregator/services/aggregator.service.spec.ts
@@ -33,6 +33,33 @@ describe('AggregatorService', () => {
     expect(spy).toBeCalledWith(token, undefined);
   });
 
+  it('should create an anonymous user and return its id', async () => {
+    const spy = jest.spyOn(client, 'createUser').mockReturnValue(
+      Promise.resolve({
+        id_user: 1,
+        auth_token: 'mickToken',
+        type: 'permanent',
+        expires_in: 3000,
+      }),
+    );
+
+    expect(await service.createUser()).toBe(1);
+    expect(spy).toBeCalledWith(undefined);
+  });
+
+  it('should get userId from its token', async () => {
+    const spy = jest.spyOn(client, 'getUser').mockReturnValue(
+      Promise.resolve({
+        id: 2,
+        signin: new Date(),
+        platform: 'mockPlatform',
+      }),
+    );
+
+    expect(await service.getUserId('mockToken')).toBe(2);
+    expect(spy).toBeCalledWith('mockToken', undefined);
+  });
+
   it('should get the jwt token', async () => {
     const spy = jest.spyOn(client, 'getUserJWT').mockReturnValue(
       Promise.resolve({
@@ -45,6 +72,20 @@ describe('AggregatorService', () => {
     await service.getJWToken();
 
     expect(spy).toBeCalled();
+  });
+
+  it('should get the jwt token from a user', async () => {
+    const spy = jest.spyOn(client, 'getUserJWT').mockReturnValue(
+      Promise.resolve({
+        jwt_token: 'mockJwt',
+        payload: {
+          domain: 'mockDomain',
+        },
+      }),
+    );
+    await service.getJWToken(undefined, 'mockUserId');
+
+    expect(spy).toBeCalledWith(undefined, 'mockUserId');
   });
 
   it('should create the webviewUrl base on the callbackUrl', () => {

--- a/src/aggregator/services/aggregator.service.ts
+++ b/src/aggregator/services/aggregator.service.ts
@@ -25,10 +25,24 @@ export class AggregatorService {
   }
 
   /**
+   * Create a user and return its id
+   */
+  public async createUser(clientConfig?: ClientConfig): Promise<number> {
+    return (await this.budgetInsightClient.createUser(clientConfig)).id_user;
+  }
+
+  /**
+   * Get a user id from its token
+   */
+  public async getUserId(token: string, clientConfig?: ClientConfig): Promise<number> {
+    return (await this.budgetInsightClient.getUser(token, clientConfig)).id;
+  }
+
+  /**
    * Get user JSON Web Token
    */
-  public async getJWToken(clientConfig?: ClientConfig): Promise<JWTokenResponse> {
-    return this.budgetInsightClient.getUserJWT(clientConfig);
+  public async getJWToken(clientConfig?: ClientConfig, userId?: string): Promise<JWTokenResponse> {
+    return this.budgetInsightClient.getUserJWT(clientConfig, userId);
   }
 
   /**

--- a/src/aggregator/services/budget-insight/budget-insight.client.ts
+++ b/src/aggregator/services/budget-insight/budget-insight.client.ts
@@ -4,6 +4,8 @@ import { AxiosResponse, AxiosRequestConfig, AxiosError } from 'axios';
 import { config } from 'node-config-ts';
 import { isNil } from 'lodash';
 import {
+  AnonymousUser,
+  User,
   Connection,
   ConnectionWrapper,
   JWTokenResponse,
@@ -83,10 +85,28 @@ export class BudgetInsightClient {
   }
 
   /**
+   * Create an anonymous user
+   */
+  public async createUser(clientConfig?: ClientConfig): Promise<AnonymousUser> {
+    const biConfig: ClientConfig = this.getClientConfig(clientConfig);
+    const url: string = `${biConfig.baseUrl}auth/init`;
+    this.logger.debug(`Create an anonymous user on ${url}`);
+
+    const resp: AxiosResponse<AnonymousUser> = await this.httpService
+      .post(url, {
+        client_id: biConfig.clientId,
+        client_secret: biConfig.clientSecret,
+      })
+      .toPromise();
+
+    return resp.data;
+  }
+
+  /**
    * Get a user JWT
    * @returns The user JWT token
    */
-  public async getUserJWT(clientConfig?: ClientConfig): Promise<JWTokenResponse> {
+  public async getUserJWT(clientConfig?: ClientConfig, userId?: string): Promise<JWTokenResponse> {
     const biConfig: ClientConfig = this.getClientConfig(clientConfig);
     const url: string = `${biConfig.baseUrl}auth/jwt`;
     this.logger.debug(`Get a user JWT on ${url}`);
@@ -95,8 +115,22 @@ export class BudgetInsightClient {
       .post(url, {
         client_id: biConfig.clientId,
         client_secret: biConfig.clientSecret,
+        id_user: userId,
       })
       .toPromise();
+
+    return resp.data;
+  }
+
+  /**
+   * Get a user
+   * @param permanentToken The user JWT token
+   */
+  public async getUser(permanentToken: string, clientConfig?: ClientConfig): Promise<User> {
+    const baseUrl: string = this.getClientConfig(clientConfig).baseUrl;
+    const url: string = `${baseUrl}/users/me`;
+    this.logger.debug(`Get a user on ${url}`);
+    const resp: AxiosResponse<User> = await this.httpService.get(url, this.setHeaders(permanentToken)).toPromise();
 
     return resp.data;
   }

--- a/src/hooks/helpers/join-user-id.helpers.ts
+++ b/src/hooks/helpers/join-user-id.helpers.ts
@@ -1,0 +1,24 @@
+import { AggregationDetails } from '../../algoan/dto/customer.objects';
+
+/**
+ * Join userId to the existing userId from the customer.aggregationDetails
+ * @param newUserId the id of the user to add to the customer
+ * @param aggregationDetails the aggregation details of the customer
+ * @returns the new aggregation details to patch in the customer
+ */
+export const joinUserId = (
+  newUserId?: string | number,
+  aggregationDetails?: AggregationDetails,
+): AggregationDetails => {
+  const userId: string = `${newUserId}`;
+
+  // Add if no user id
+  if (aggregationDetails?.userId === undefined) {
+    return { userId };
+  }
+
+  // Add if user id does not already exist in the customer
+  return aggregationDetails.userId.split(',').includes(userId)
+    ? {}
+    : { userId: `${aggregationDetails.userId},${userId}` };
+};

--- a/src/hooks/services/hooks.service.spec.ts
+++ b/src/hooks/services/hooks.service.spec.ts
@@ -291,6 +291,8 @@ describe('HooksService', () => {
           Promise.resolve({ jwt_token: 'fake_jwt_token', payload: { domain: 'http://fake.domain.url' } }),
         );
 
+      const createUserSpy = jest.spyOn(aggregatorService, 'createUser').mockResolvedValue(10);
+
       const spyPatchCustomer = jest
         .spyOn(algoanCustomerService, 'updateCustomer')
         .mockReturnValue(Promise.resolve(({} as unknown) as Customer));
@@ -307,6 +309,7 @@ describe('HooksService', () => {
 
       expect(spyHttpService).toBeCalled();
       expect(spyGetCustomer).toBeCalledWith('mockCustomerId');
+      expect(createUserSpy).toBeCalledWith(fakeServiceAccount.config);
       expect(spyGetJWT).toBeCalledWith({ baseUrl: 'https://fake-base-url.url', clientId: 'fakeClientId' });
       expect(spyPatchCustomer).toBeCalledWith('mockCustomerId', {
         aggregationDetails: {
@@ -314,6 +317,7 @@ describe('HooksService', () => {
           apiUrl: 'https://fake-base-url.url',
           clientId: 'fakeClientId',
           token: 'fake_jwt_token',
+          userId: '10',
         },
       });
     });
@@ -430,9 +434,7 @@ describe('HooksService', () => {
           aggregationDetails: { mode: AggregationDetailsMode.API, token: 'fakeToken' },
         } as unknown) as Customer),
       );
-      const updateCustomerSpy = jest.spyOn(algoanCustomerService, 'updateCustomer').mockResolvedValue({} as Customer);
 
-      const createUserSpy = jest.spyOn(aggregatorService, 'createUser').mockResolvedValue(10);
       const connectionSpy = jest
         .spyOn(aggregatorService, 'getConnections')
         .mockReturnValueOnce(Promise.resolve([connection]))
@@ -471,8 +473,6 @@ describe('HooksService', () => {
 
       expect(spyHttpService).toBeCalled();
       expect(spyGetCustomer).toBeCalledWith('mockCustomerId');
-      expect(updateCustomerSpy).toBeCalledWith('mockCustomerId', { aggregationDetails: { userId: '10' } });
-      expect(createUserSpy).toBeCalledWith(saConfig);
       expect(connectionSpy).toBeCalledWith('fakeToken', saConfig);
       expect(accountSpy).toBeCalledWith('fakeToken', saConfig);
       expect(userInfoSpy).toBeCalledWith('fakeToken', '4', saConfig);

--- a/src/hooks/services/hooks.service.ts
+++ b/src/hooks/services/hooks.service.ts
@@ -156,6 +156,10 @@ export class HooksService {
         /** Get the JWT token */
         const token = await this.aggregator.getJWToken(serviceAccountConfig);
         aggregationDetails.token = token.jwt_token;
+
+        /** Create a user */
+        const newUserId: number = await this.aggregator.createUser(serviceAccount.config as ClientConfig);
+        aggregationDetails.userId = joinUserId(newUserId, customer.aggregationDetails).userId;
         break;
 
       default:
@@ -211,7 +215,7 @@ export class HooksService {
 
       case AggregationDetailsMode.API:
         if (customer.aggregationDetails?.userId === undefined) {
-          newUserId = await this.aggregator.createUser(serviceAccount.config as ClientConfig);
+          this.logger.warn('User Id should be defined in API bank connection mode');
         }
         break;
 


### PR DESCRIPTION
The goal of this PR is to refresh the bank details previously aggregated from one customer without requiring a new authentication from the end-user.

For this, we connect again with the user created on the first aggregation.