### PR TITLE
[FIX] Keep only one userId per Customer

### DIFF
--- a/src/aggregator/interfaces/budget-insight.interface.ts
+++ b/src/aggregator/interfaces/budget-insight.interface.ts
@@ -191,6 +191,7 @@ export interface JWTokenResponse {
   jwt_token: string;
   payload: {
     domain: string;
+    id_user: string;
   };
 }
 

--- a/src/aggregator/services/aggregator.service.spec.ts
+++ b/src/aggregator/services/aggregator.service.spec.ts
@@ -66,6 +66,7 @@ describe('AggregatorService', () => {
         jwt_token: 'mockJwt',
         payload: {
           domain: 'mockDomain',
+          id_user: 'userId',
         },
       }),
     );
@@ -80,6 +81,7 @@ describe('AggregatorService', () => {
         jwt_token: 'mockJwt',
         payload: {
           domain: 'mockDomain',
+          id_user: 'userId',
         },
       }),
     );

--- a/src/aggregator/services/budget-insight/budget-insight.client.spec.ts
+++ b/src/aggregator/services/budget-insight/budget-insight.client.spec.ts
@@ -88,6 +88,7 @@ describe('BudgetInsightClient', () => {
       jwt_token: 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9',
       payload: {
         domain: 'algoan-testa-sandbox.biapi.pro',
+        id_user: 'userId',
       },
     };
     result.data = jwtReturn;
@@ -107,6 +108,7 @@ describe('BudgetInsightClient', () => {
       jwt_token: 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9',
       payload: {
         domain: 'algoan-testa-sandbox.biapi.pro',
+        id_user: 'userId',
       },
     };
     result.data = jwtReturn;

--- a/src/hooks/services/hooks.service.spec.ts
+++ b/src/hooks/services/hooks.service.spec.ts
@@ -286,13 +286,12 @@ describe('HooksService', () => {
         } as unknown) as Customer),
       );
 
-      const spyGetJWT = jest
-        .spyOn(aggregatorService, 'getJWToken')
-        .mockReturnValue(
-          Promise.resolve({ jwt_token: 'fake_jwt_token', payload: { domain: 'http://fake.domain.url' } }),
-        );
-
-      const createUserSpy = jest.spyOn(aggregatorService, 'createUser').mockResolvedValue(10);
+      const spyGetJWT = jest.spyOn(aggregatorService, 'getJWToken').mockReturnValue(
+        Promise.resolve({
+          jwt_token: 'fake_jwt_token',
+          payload: { domain: 'http://fake.domain.url', id_user: 'userId' },
+        }),
+      );
 
       const spyPatchCustomer = jest
         .spyOn(algoanCustomerService, 'updateCustomer')
@@ -310,15 +309,14 @@ describe('HooksService', () => {
 
       expect(spyHttpService).toBeCalled();
       expect(spyGetCustomer).toBeCalledWith('mockCustomerId');
-      expect(createUserSpy).toBeCalledWith(fakeServiceAccount.config);
-      expect(spyGetJWT).toBeCalledWith({ baseUrl: 'https://fake-base-url.url', clientId: 'fakeClientId' });
+      expect(spyGetJWT).toBeCalledWith({ baseUrl: 'https://fake-base-url.url', clientId: 'fakeClientId' }, undefined);
       expect(spyPatchCustomer).toBeCalledWith('mockCustomerId', {
         aggregationDetails: {
           aggregatorName: 'BUDGET_INSIGHT',
           apiUrl: 'https://fake-base-url.url',
           clientId: 'fakeClientId',
           token: 'fake_jwt_token',
-          userId: '10',
+          userId: 'userId',
         },
       });
     });
@@ -540,7 +538,7 @@ describe('HooksService', () => {
 
       const jwtTokenSpy = jest
         .spyOn(aggregatorService, 'getJWToken')
-        .mockResolvedValue({ jwt_token: 'mockPermToken', payload: { domain: 'mockDomain' } });
+        .mockResolvedValue({ jwt_token: 'mockPermToken', payload: { domain: 'mockDomain', id_user: 'userId' } });
 
       const connectionSpy = jest
         .spyOn(aggregatorService, 'getConnections')

--- a/src/hooks/services/hooks.service.ts
+++ b/src/hooks/services/hooks.service.ts
@@ -154,12 +154,9 @@ export class HooksService {
 
       case AggregationDetailsMode.API:
         /** Get the JWT token */
-        const token = await this.aggregator.getJWToken(serviceAccountConfig);
+        const token = await this.aggregator.getJWToken(serviceAccountConfig, customer.aggregationDetails.userId);
         aggregationDetails.token = token.jwt_token;
-
-        /** Create a user */
-        const newUserId: number = await this.aggregator.createUser(serviceAccount.config as ClientConfig);
-        aggregationDetails.userId = joinUserId(newUserId, customer.aggregationDetails).userId;
+        aggregationDetails.userId = token.payload.id_user;
         break;
 
       default:


### PR DESCRIPTION
## Description

Instead of creating a new userId each time we are asking for aggregation configs, we keep the same userId