### PR TITLE
[FEAT] Add ownership to Account

### DIFF
--- a/src/aggregator/interfaces/budget-insight-mock.ts
+++ b/src/aggregator/interfaces/budget-insight-mock.ts
@@ -1,10 +1,11 @@
 import {
-  BudgetInsightAccount,
   AccountType,
+  BankAccountOwnership,
+  BankAccountUsage,
+  BudgetInsightAccount,
+  BudgetInsightCategory,
   BudgetInsightTransaction,
   TransactionType,
-  BudgetInsightCategory,
-  BankAccountUsage,
 } from './budget-insight.interface';
 
 export const mockAccount: BudgetInsightAccount = {
@@ -27,6 +28,7 @@ export const mockAccount: BudgetInsightAccount = {
   disabled: false,
   company_name: 'mockCompany',
   usage: BankAccountUsage.PRIVATE,
+  ownership: BankAccountOwnership.OWNER,
 };
 
 export const mockTransaction: BudgetInsightTransaction = {

--- a/src/aggregator/interfaces/budget-insight.interface.ts
+++ b/src/aggregator/interfaces/budget-insight.interface.ts
@@ -62,6 +62,7 @@ export interface BudgetInsightAccount {
   bic: string;
   loan?: Loan | null;
   usage: BankAccountUsage;
+  ownership: BankAccountOwnership | null;
   disabled: boolean;
   company_name: string | null;
 }
@@ -211,6 +212,16 @@ export enum BankAccountUsage {
   PRIVATE = 'PRIV',
   PROFESSIONAL = 'ORGA',
   ASSOCIATION = 'ASSO',
+}
+
+/**
+ * Relationship between the credentials owner and the account
+ * https://docs.budget-insight.com/reference/bank-accounts#bankaccountownership-values
+ */
+export enum BankAccountOwnership {
+  OWNER = 'owner',
+  CO_OWNER = 'co-owner',
+  ATTORNEY = 'attorney',
 }
 
 /**

--- a/src/aggregator/services/budget-insight/budget-insight.client.spec.ts
+++ b/src/aggregator/services/budget-insight/budget-insight.client.spec.ts
@@ -15,7 +15,7 @@ import {
   ConnectionWrapper,
 } from '../../interfaces/budget-insight.interface';
 import { mockAccount, mockTransaction, mockCategory } from '../../interfaces/budget-insight-mock';
-import { ClientConfig } from '../budget-insight/budget-insight.client';
+import { ClientConfig } from './budget-insight.client';
 describe('BudgetInsightClient', () => {
   let service: BudgetInsightClient;
   let httpService: HttpService;

--- a/src/aggregator/services/budget-insight/budget-insight.utils.spec.ts
+++ b/src/aggregator/services/budget-insight/budget-insight.utils.spec.ts
@@ -1,12 +1,13 @@
 import { BanksUserTransactionType as TransactionType } from '@algoan/rest';
 import { Test, TestingModule } from '@nestjs/testing';
-import { AccountLoanType, AccountType, AccountUsage } from '../../../algoan/dto/analysis.enum';
+import { AccountLoanType, AccountOwnership, AccountType, AccountUsage } from '../../../algoan/dto/analysis.enum';
 import { Account as AnalysisAccount, AccountTransactions } from '../../../algoan/dto/analysis.inputs';
 import { AggregatorModule } from '../../aggregator.module';
 import { mockCategory } from '../../interfaces/budget-insight-mock';
 import {
   AccountType as BIAccountType,
   Bank,
+  BankAccountOwnership,
   BankAccountUsage as BIUsageType,
   BudgetInsightAccount,
   BudgetInsightCategory,
@@ -74,6 +75,7 @@ describe('BudgetInsightUtils', () => {
         name: 'account-name',
         type: BIAccountType.LOAN,
         usage: BIUsageType.PRIVATE,
+        ownership: BankAccountOwnership.CO_OWNER,
         disabled: false,
         company_name: 'mockCompanyName',
         loan: {
@@ -105,6 +107,7 @@ describe('BudgetInsightUtils', () => {
         name: 'account-name',
         type: BIAccountType.CARD,
         usage: BIUsageType.PRIVATE,
+        ownership: null,
         disabled: false,
         company_name: 'mockCompanyName',
       },
@@ -140,6 +143,7 @@ describe('BudgetInsightUtils', () => {
         number: 'mockNumber',
         type: AccountType.LOAN,
         usage: AccountUsage.PERSONAL,
+        ownership: AccountOwnership.CO_HOLDER,
         owners: [{ name: 'M. JOHN DOE' }],
         aggregator: {
           id: '1',
@@ -168,6 +172,7 @@ describe('BudgetInsightUtils', () => {
         },
         type: AccountType.CREDIT_CARD,
         usage: AccountUsage.PERSONAL,
+        ownership: undefined,
         owners: [{ name: 'M. JOHN DOE' }],
       },
     ];
@@ -210,6 +215,7 @@ describe('BudgetInsightUtils', () => {
         name: 'account-name',
         type: BIAccountType.UNKNOWN,
         usage: 'UNKNOWN' as unknown as BIUsageType,
+        ownership: 'foo' as BankAccountOwnership,
         disabled: false,
         company_name: 'mockCompanyName',
         loan: {
@@ -241,6 +247,7 @@ describe('BudgetInsightUtils', () => {
         name: 'account-name',
         type: BIAccountType.CARD,
         usage: BIUsageType.PRIVATE,
+        ownership: BankAccountOwnership.ATTORNEY,
         disabled: false,
         company_name: 'mockCompanyName',
       },
@@ -275,6 +282,7 @@ describe('BudgetInsightUtils', () => {
         number: 'mockNumber',
         type: AccountType.UNKNOWN,
         usage: AccountUsage.UNKNOWN,
+        ownership: AccountOwnership.OTHER,
         owners: undefined,
         aggregator: {
           id: '1',
@@ -302,6 +310,7 @@ describe('BudgetInsightUtils', () => {
         },
         type: AccountType.CREDIT_CARD,
         usage: AccountUsage.PERSONAL,
+        ownership: AccountOwnership.ATTORNEY,
         owners: undefined,
       },
     ];

--- a/src/aggregator/services/budget-insight/budget-insight.utils.ts
+++ b/src/aggregator/services/budget-insight/budget-insight.utils.ts
@@ -1,11 +1,12 @@
 import { BanksUserTransactionType as TransactionType } from '@algoan/rest';
 import { get, isNil } from 'lodash';
 import * as moment from 'moment-timezone';
-import { AccountLoanType, AccountType, AccountUsage } from '../../../algoan/dto/analysis.enum';
+import { AccountLoanType, AccountOwnership, AccountType, AccountUsage } from '../../../algoan/dto/analysis.enum';
 import { Account as AnalysisAccount, AccountTransactions } from '../../../algoan/dto/analysis.inputs';
 import {
   AccountType as BiAccountType,
   Bank,
+  BankAccountOwnership as BiOwnershipType,
   BankAccountUsage as BiUsageType,
   BudgetInsightAccount,
   BudgetInsightOwner,
@@ -53,6 +54,7 @@ const fromBIToAlgoanAccounts = (
   currency: account.currency?.id,
   type: mapAccountType(account.type),
   usage: mapUsageType(account.usage),
+  ownership: mapOwnershipType(account.ownership),
   owners: !isNil(ownerInfo) && !isNil(ownerInfo?.owner?.name) ? [{ name: ownerInfo.owner.name }] : undefined,
   iban: account.iban === null ? undefined : account.iban,
   bic: account.bic,
@@ -229,3 +231,23 @@ const mapUsageType = (usageType: BiUsageType): AccountUsage => USAGE_TYPE_MAPPIN
  * Undefined category id
  */
 const undefinedCategory: number = 9998;
+
+/**
+ * OwnershipType TypeMapping
+ */
+interface OwnershipTypeMapping {
+  [index: string]: AccountOwnership;
+}
+
+const OWNERSHIP_TYPE_MAPPING: OwnershipTypeMapping = {
+  [BiOwnershipType.OWNER]: AccountOwnership.HOLDER,
+  [BiOwnershipType.CO_OWNER]: AccountOwnership.CO_HOLDER,
+  [BiOwnershipType.ATTORNEY]: AccountOwnership.ATTORNEY,
+};
+
+/**
+ * mapOwnershipType map the ownership type from the Budget Insights
+ * @param ownershipType Budget Insight ownership type
+ */
+const mapOwnershipType = (ownershipType: BiOwnershipType | null): AccountOwnership | undefined =>
+  ownershipType ? OWNERSHIP_TYPE_MAPPING[ownershipType] ?? AccountOwnership.OTHER : undefined;

--- a/src/algoan/dto/analysis.enum.ts
+++ b/src/algoan/dto/analysis.enum.ts
@@ -31,6 +31,16 @@ export enum AccountUsage {
 }
 
 /**
+ * Account Ownership enum
+ */
+export enum AccountOwnership {
+  HOLDER = 'HOLDER',
+  CO_HOLDER = 'CO_HOLDER',
+  ATTORNEY = 'ATTORNEY',
+  OTHER = 'OTHER',
+}
+
+/**
  * Account Sing Type enum
  */
 export enum AccountSavingType {

--- a/src/algoan/dto/analysis.inputs.ts
+++ b/src/algoan/dto/analysis.inputs.ts
@@ -1,4 +1,11 @@
-import { AccountType, AccountUsage, AccountSavingType, AccountLoanType, AnalysisStatus } from './analysis.enum';
+import {
+  AccountType,
+  AccountUsage,
+  AccountSavingType,
+  AccountLoanType,
+  AnalysisStatus,
+  AccountOwnership,
+} from './analysis.enum';
 import { AnalysisError } from './analysis.objects';
 
 /**
@@ -19,6 +26,7 @@ export interface Account {
   currency: string; // ISO4217
   type: AccountType;
   usage: AccountUsage;
+  ownership?: AccountOwnership;
   owners?: AccountOwner[];
   iban?: string;
   bic?: string;

--- a/src/hooks/services/hooks.service.spec.ts
+++ b/src/hooks/services/hooks.service.spec.ts
@@ -516,6 +516,7 @@ describe('HooksService', () => {
             ],
             type: 'CHECKING',
             usage: 'PERSONAL',
+            ownership: 'HOLDER',
           },
         ],
       });
@@ -614,6 +615,7 @@ describe('HooksService', () => {
             ],
             type: 'CHECKING',
             usage: 'PERSONAL',
+            ownership: 'HOLDER',
           },
         ],
       });
@@ -714,6 +716,7 @@ describe('HooksService', () => {
             ],
             type: 'CHECKING',
             usage: 'PERSONAL',
+            ownership: 'HOLDER',
           },
           {
             aggregator: { id: '1' },
@@ -740,6 +743,7 @@ describe('HooksService', () => {
             ],
             type: 'CHECKING',
             usage: 'PERSONAL',
+            ownership: 'HOLDER',
           },
         ],
       });
@@ -840,6 +844,7 @@ describe('HooksService', () => {
             ],
             type: 'CHECKING',
             usage: 'PERSONAL',
+            ownership: 'HOLDER',
           },
         ],
       });


### PR DESCRIPTION
# Description
This pull request aims to retrieve the field `ownership` from Budget Insight account and to map it to Analysis account.

# Documentation
[Link](https://docs.budget-insight.com/reference/bank-accounts#bankaccountownership-values) to the Budget Insight documentation.