### PR TITLE
[FIX] Fix the renew and init responses

### DIFF
--- a/src/aggregator/interfaces/budget-insight.interface.ts
+++ b/src/aggregator/interfaces/budget-insight.interface.ts
@@ -197,6 +197,25 @@ export interface JWTokenResponse {
 }
 
 /**
+ * Access Token Response
+ * https://docs.budget-insight.com/reference/authentication#generate-a-user-scoped-token
+ */
+export interface AccessTokenResponse {
+  access_token: string;
+  token_type: string;
+}
+
+/**
+ * Auth Token Respone
+ * https://docs.budget-insight.com/reference/authentication#generate-a-user-scoped-token
+ */
+export interface AuthJWTokenResponse {
+  auth_token: string;
+  type: string;
+  id_user: string;
+}
+
+/**
  * Body returned after registration
  */
 export interface AuthTokenResponse {

--- a/src/aggregator/services/budget-insight/budget-insight.client.spec.ts
+++ b/src/aggregator/services/budget-insight/budget-insight.client.spec.ts
@@ -87,11 +87,17 @@ describe('BudgetInsightClient', () => {
     const jwtReturn: JWTokenResponse = {
       jwt_token: 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9',
       payload: {
-        domain: 'algoan-testa-sandbox.biapi.pro',
+        domain: 'https://fake-budget-insights.com/2.0',
         id_user: 'userId',
       },
     };
-    result.data = jwtReturn;
+
+    result.data = {
+      auth_token: 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9',
+      type: 'permanent',
+      id_user: 'userId',
+    };
+
     const spy = jest.spyOn(httpService, 'post').mockImplementationOnce(() => of(result));
 
     const jwtResponse = await service.getNewUserJWT();
@@ -111,11 +117,16 @@ describe('BudgetInsightClient', () => {
     const jwtReturn: JWTokenResponse = {
       jwt_token: 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9',
       payload: {
-        domain: 'algoan-testa-sandbox.biapi.pro',
-        id_user: 'userId',
+        domain: 'https://fake-budget-insights.com/2.0',
+        id_user: 'mockUserId',
       },
     };
-    result.data = jwtReturn;
+
+    result.data = {
+      access_token: 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9',
+      token_type: 'Bearer',
+    };
+
     const spy = jest.spyOn(httpService, 'post').mockImplementationOnce(() => of(result));
 
     const jwtResponse = await service.getExistingUserJWT(undefined, 'mockUserId');

--- a/src/aggregator/services/budget-insight/budget-insight.client.ts
+++ b/src/aggregator/services/budget-insight/budget-insight.client.ts
@@ -19,6 +19,8 @@ import {
   AccountWrapper,
   BudgetInsightCategory,
   BudgetInsightOwner,
+  AccessTokenResponse,
+  AuthJWTokenResponse,
 } from '../../interfaces/budget-insight.interface';
 const DEFAULT_NUMBER_OF_MONTHS: number = 5;
 /**
@@ -113,7 +115,7 @@ export class BudgetInsightClient {
     this.logger.debug(`Get a user JWT on ${url}`);
 
     try {
-      const resp: AxiosResponse<JWTokenResponse> = await this.toPromise(
+      const resp: AxiosResponse<AccessTokenResponse> = await this.toPromise(
         this.httpService.post(
           url,
           {
@@ -132,7 +134,15 @@ export class BudgetInsightClient {
         ),
       );
 
-      return resp.data;
+      const response: JWTokenResponse = {
+        jwt_token: resp.data.access_token,
+        payload: {
+          domain: biConfig.baseUrl,
+          id_user: userId as string,
+        },
+      };
+
+      return response;
     } catch (err) {
       this.logger.error("An error occurred when generating user's JWT token");
       throw new UnauthorizedException(err);
@@ -149,7 +159,7 @@ export class BudgetInsightClient {
     this.logger.debug(`Get a user JWT on ${url}`);
 
     try {
-      const resp: AxiosResponse<JWTokenResponse> = await this.toPromise(
+      const resp: AxiosResponse<AuthJWTokenResponse> = await this.toPromise(
         this.httpService.post(
           url,
           {
@@ -165,7 +175,15 @@ export class BudgetInsightClient {
         ),
       );
 
-      return resp.data;
+      const response: JWTokenResponse = {
+        jwt_token: resp.data.auth_token,
+        payload: {
+          domain: biConfig.baseUrl,
+          id_user: resp.data.id_user,
+        },
+      };
+
+      return response;
     } catch (err) {
       this.logger.error("An error occurred when generating new user's JWT token");
       throw new UnauthorizedException(err);

--- a/test/utils/budget-insight.fake-server.ts
+++ b/test/utils/budget-insight.fake-server.ts
@@ -60,28 +60,21 @@ const fakeTransactions = [
  * Mock the /auth/renew API
  */
 export const getExistingUserJwt = (): nock.Scope => {
-  return nock(config.budgetInsight.url)
-    .post('/auth/renew')
-    .reply(HttpStatus.OK, {
-      jwt_token: 'bi_token',
-      payload: {
-        id_user: 'user_id',
-      },
-    });
+  return nock(config.budgetInsight.url).post('/auth/renew').reply(HttpStatus.OK, {
+    access_token: 'bi_token',
+    token_type: 'Bearer',
+  });
 };
 
 /**
  * Mock the /auth/init API
  */
 export const getNewUserJwt = (): nock.Scope => {
-  return nock(config.budgetInsight.url)
-    .post('/auth/init')
-    .reply(HttpStatus.OK, {
-      jwt_token: 'bi_token',
-      payload: {
-        id_user: 'user_id',
-      },
-    });
+  return nock(config.budgetInsight.url).post('/auth/init').reply(HttpStatus.OK, {
+    auth_token: 'bi_token',
+    type: 'permanent',
+    id_user: 'user_id',
+  });
 };
 
 /**


### PR DESCRIPTION
## Description 

After the update of their API, the auth/renew and auth/init calls have a different response body from the auth/jwt call.
In this PR we made the conversion from the renew and init body response to our response body for the API mode function.