### PR TITLE
feat: allow connector to get bank data in IFRAME mode

### DIFF
--- a/src/hooks/services/hooks.service.spec.ts
+++ b/src/hooks/services/hooks.service.spec.ts
@@ -1018,7 +1018,7 @@ describe('HooksService', () => {
       });
     });
 
-    it('without token in the customer but a temporaryCode', async () => {
+    it('without token in the customer but a temporaryCode - REDIRECT mode', async () => {
       const mockSubscription: Subscription = {
         event: (_id: string) => ({
           update: async ({ status }) => {
@@ -1031,6 +1031,107 @@ describe('HooksService', () => {
         Promise.resolve({
           id: 'mockCustomerId',
           aggregationDetails: { mode: AggregationDetailsMode.REDIRECT },
+        } as unknown as Customer),
+      );
+      const updateCustomerSpy = jest.spyOn(algoanCustomerService, 'updateCustomer').mockResolvedValue({} as Customer);
+
+      const registerSpy = jest.spyOn(aggregatorService, 'registerClient').mockResolvedValue('mockPermToken');
+      const userIdSpy = jest.spyOn(aggregatorService, 'getUserId').mockResolvedValue(12);
+
+      const connectionSpy = jest
+        .spyOn(aggregatorService, 'getConnections')
+        .mockReturnValueOnce(Promise.resolve([connection]))
+        .mockReturnValueOnce(Promise.resolve([{ ...connection, last_update: 'mockLastUpdate' }]));
+      const accountSpy = jest.spyOn(aggregatorService, 'getAccounts').mockResolvedValue([mockAccount]);
+      const userInfoSpy = jest.spyOn(aggregatorService, 'getInfo').mockResolvedValue({ owner: { name: 'JOHN DOE' } });
+      const transactionSpy = jest.spyOn(aggregatorService, 'getTransactions').mockResolvedValue([mockTransaction]);
+      const categorySpy = jest.spyOn(aggregatorService, 'getCategory').mockResolvedValue(mockCategory);
+      const analysisSpy = jest
+        .spyOn(algoanAnalysisService, 'updateAnalysis')
+        .mockReturnValue(Promise.resolve({} as unknown as Analysis));
+
+      const event: EventDTO = {
+        ...mockEvent,
+        subscription: {
+          ...mockEvent,
+          eventName: EventName.BANK_DETAILS_REQUIRED,
+        },
+        payload: { customerId: 'mockCustomerId', analysisId: 'mockAnalysisId', temporaryCode: 'mockTempCode' },
+      } as unknown as EventDTO;
+
+      const fakeServiceAccount: ServiceAccount = {
+        ...mockServiceAccount,
+        config: {
+          baseUrl: 'https://fake-base-url.url',
+          clientId: 'fakeClientId',
+        },
+      } as ServiceAccount;
+
+      await hooksService.dispatchAndHandleWebhook(event, mockSubscription, fakeServiceAccount, new Date());
+
+      const saConfig = {
+        baseUrl: 'https://fake-base-url.url',
+        clientId: 'fakeClientId',
+      };
+
+      expect(spyHttpService).toBeCalled();
+      expect(spyGetCustomer).toBeCalledWith('mockCustomerId');
+      expect(updateCustomerSpy).toBeCalledWith('mockCustomerId', { aggregationDetails: { userId: '12' } });
+      expect(registerSpy).toBeCalledWith(mockEvent.payload.temporaryCode, saConfig);
+      expect(userIdSpy).toBeCalledWith('mockPermToken', saConfig);
+      expect(connectionSpy).toBeCalledWith('mockPermToken', saConfig);
+      expect(connectionSpy).toBeCalledTimes(2);
+      expect(accountSpy).toBeCalledWith('mockPermToken', saConfig);
+      expect(userInfoSpy).toBeCalledWith('mockPermToken', '4', saConfig);
+      expect(userInfoSpy).toBeCalledTimes(1);
+      expect(transactionSpy).toBeCalledWith('mockPermToken', 1, saConfig);
+      expect(categorySpy).toBeCalledWith('mockPermToken', mockTransaction.id_category, saConfig);
+      expect(analysisSpy).toBeCalledWith('mockCustomerId', 'mockAnalysisId', {
+        accounts: [
+          {
+            aggregator: { id: '1' },
+            balance: 100,
+            balanceDate: '2011-10-05T14:48:00.000Z',
+            bank: { id: undefined, name: undefined },
+            bic: 'mockBic',
+            coming: 0,
+            currency: 'id1',
+            details: { loan: undefined, savings: undefined },
+            iban: 'mockIban',
+            name: 'mockName',
+            number: 'mockNumber',
+            owners: undefined,
+            transactions: [
+              {
+                aggregator: { category: 'mockCategoryName', id: 'mockId', type: 'BANK_FEE' },
+                amount: 50,
+                currency: 'USD',
+                dates: { bookedAt: null, debitedAt: null },
+                description: 'mockOriginalWording',
+                isComing: false,
+              },
+            ],
+            type: 'CHECKING',
+            usage: 'PERSONAL',
+            ownership: 'HOLDER',
+          },
+        ],
+      });
+    });
+
+    it('without token in the customer but a temporaryCode - IFRAME mode', async () => {
+      const mockSubscription: Subscription = {
+        event: (_id: string) => ({
+          update: async ({ status }) => {
+            expect(status).toEqual('PROCESSED');
+          },
+        }),
+      } as unknown as Subscription;
+
+      const spyGetCustomer = jest.spyOn(algoanCustomerService, 'getCustomerById').mockReturnValue(
+        Promise.resolve({
+          id: 'mockCustomerId',
+          aggregationDetails: { mode: AggregationDetailsMode.IFRAME },
         } as unknown as Customer),
       );
       const updateCustomerSpy = jest.spyOn(algoanCustomerService, 'updateCustomer').mockResolvedValue({} as Customer);

--- a/src/hooks/services/hooks.service.ts
+++ b/src/hooks/services/hooks.service.ts
@@ -237,6 +237,7 @@ export class HooksService {
       let newUserId: number | undefined;
       switch (customer.aggregationDetails?.mode) {
         case AggregationDetailsMode.REDIRECT:
+        case AggregationDetailsMode.IFRAME:
           if (payload.temporaryCode !== undefined && permanentToken === undefined) {
             permanentToken = await this.aggregator.registerClient(
               payload.temporaryCode,


### PR DESCRIPTION
# Documentation

During the test of Budget Insight `IFRAME` mode, we noticed that the bank data were never retrieved. That is because the retrieval of Budget Insight token was not implemented for this mode (Datadog sent the warning `Invalid bank connection mode IFRAME`).

Since the data sent in the iframe flow are exactly the same as the redirect flow, the change is straightforward.
