### PR TITLE
[TP-11668] Delete automatically users after account recuperation 

### DIFF
--- a/src/aggregator/services/aggregator.service.ts
+++ b/src/aggregator/services/aggregator.service.ts
@@ -39,6 +39,13 @@ export class AggregatorService {
   }
 
   /**
+   * Delete a user by it's id
+   */
+  public async deleteUser(id: number, permanentToken: string, clientConfig?: ClientConfig): Promise<void> {
+    return this.budgetInsightClient.deleteUser(id, permanentToken, clientConfig);
+  }
+
+  /**
    * Get user JSON Web Token
    */
   public async getJWTokenForExistingUser(clientConfig?: ClientConfig, userId?: string): Promise<JWTokenResponse> {

--- a/src/aggregator/services/budget-insight/budget-insight.client.spec.ts
+++ b/src/aggregator/services/budget-insight/budget-insight.client.spec.ts
@@ -16,6 +16,7 @@ import {
 } from '../../interfaces/budget-insight.interface';
 import { mockAccount, mockTransaction, mockCategory } from '../../interfaces/budget-insight-mock';
 import { ClientConfig } from './budget-insight.client';
+
 describe('BudgetInsightClient', () => {
   let service: BudgetInsightClient;
   let httpService: HttpService;
@@ -325,6 +326,27 @@ describe('BudgetInsightClient', () => {
       baseUrl: 'http://test.url/2.0',
       clientId: 'testClientId',
       clientSecret: 'testClientSecret',
+    });
+  });
+
+  it('delete the user after the account recuperation if deleteUser is true', async () => {
+    const user: User = {
+      id: 3,
+      platform: 'mockPlatform',
+      signin: new Date(),
+    };
+
+    const permanentToken = 'token';
+
+    const spy = jest.spyOn(httpService, 'delete').mockImplementationOnce(() => of(result));
+
+    await service.deleteUser(user.id, permanentToken);
+
+    expect(spy).toHaveBeenCalledWith(`https://fake-budget-insights.com/2.0/users/${user.id}`, {
+      headers: {
+        ...headers.headers,
+        Authorization: `Bearer ${permanentToken}`,
+      },
     });
   });
 });

--- a/src/aggregator/services/budget-insight/budget-insight.client.ts
+++ b/src/aggregator/services/budget-insight/budget-insight.client.ts
@@ -32,6 +32,7 @@ export interface ClientConfig {
   baseUrl: string;
   nbOfMonths?: number;
   language?: string;
+  deleteUsers?: boolean;
 }
 
 /**
@@ -304,7 +305,6 @@ export class BudgetInsightClient {
       }&min_date=${startDate.toISOString()}&max_date=${endDate.toISOString()}`;
       url = `${baseUrl}${uri}`;
       resp = await this.toPromise(this.httpService.get(url, this.setHeaders(permanentToken)));
-
       transactions = [...transactions, ...resp.data.transactions];
 
       offset++;
@@ -331,6 +331,19 @@ export class BudgetInsightClient {
     );
 
     return resp.data;
+  }
+
+  /**
+   * Delete user by its id
+   * https://docs.budget-insight.com/reference/users#delete-a-user
+   * @param permanentToken The Budget Insight token
+   */
+  public async deleteUser(id: number, permanentToken: string, clientConfig?: ClientConfig): Promise<void> {
+    const biConfig: ClientConfig = this.getClientConfig(clientConfig);
+    const url: string = `${biConfig.baseUrl}/users/${id}`;
+    this.logger.debug(`Deleting the connexion with the id ${id}`);
+
+    await this.toPromise(this.httpService.delete(url, this.setHeaders(permanentToken)));
   }
 
   /**

--- a/src/hooks/services/hooks.service.ts
+++ b/src/hooks/services/hooks.service.ts
@@ -286,6 +286,12 @@ export class HooksService {
         payload,
         serviceAccount.config as ClientConfig,
       );
+
+      // We remove the user if deleteUsers is set to true
+      if ((serviceAccount.config as ClientConfig)?.deleteUsers === true && newUserId !== undefined) {
+        await this.aggregator.deleteUser(newUserId, permanentToken, serviceAccount.config as ClientConfig);
+      }
+
       if (algoanAccounts === undefined) {
         return;
       }


### PR DESCRIPTION
## Documentation

In this PR we allowed the user suppression after the accounts and transactions recuperation. This suppression is only done if the ClientConfig value `deleteUser`is set to true