### PR TITLE
[FIX] Fix removed logoUrl

### DIFF
--- a/src/aggregator/interfaces/enriched-budget-insight.interface.ts
+++ b/src/aggregator/interfaces/enriched-budget-insight.interface.ts
@@ -26,7 +26,8 @@ export type EnrichedAccount = BudgetInsightAccount & { transactions?: EnrichedBu
  *
  * Connection with a matching connector and information data with the account list
  */
-export type EnrichedConnection = Partial<Connection> & {
+export type EnrichedConnection = Partial<Omit<Connection, 'connector'>> & {
+  connector?: Partial<Connection['connector']> & { logoUrl?: string };
   accounts: EnrichedAccount[];
   information?: BudgetInsightOwner;
 };

--- a/src/aggregator/services/budget-insight/budget-insight.utils.spec.ts
+++ b/src/aggregator/services/budget-insight/budget-insight.utils.spec.ts
@@ -123,7 +123,12 @@ describe('BudgetInsightUtils', () => {
         last_update: '',
         state: null,
         active: true,
-        connector: { id: 2, uuid: 'example-uuid', name: 'bank-name' },
+        connector: {
+          id: 2,
+          uuid: 'example-uuid',
+          name: 'bank-name',
+          logoUrl: 'https://fake-budget-insights.com/2.0/logos/example-uuid-thumbnail@2x.png',
+        },
         created: budgetInsightConnections[0].created,
         next_try: budgetInsightConnections[0].next_try,
         accounts: [
@@ -171,7 +176,12 @@ describe('BudgetInsightUtils', () => {
         last_update: '',
         state: null,
         active: true,
-        connector: { id: 2, uuid: 'example-uuid', name: 'bank-name' },
+        connector: {
+          id: 2,
+          uuid: 'example-uuid',
+          name: 'bank-name',
+          logoUrl: 'https://fake-budget-insights.com/2.0/logos/example-uuid-thumbnail@2x.png',
+        },
         created: budgetInsightConnections[0].created,
         next_try: budgetInsightConnections[0].next_try,
         accounts: [
@@ -203,9 +213,9 @@ describe('BudgetInsightUtils', () => {
       },
     ];
 
-    expect(mapBudgetInsightAccount(budgetInsightAccounts, budgetInsightConnections, ownerInfo)).toEqual(
-      expectedConnections,
-    );
+    expect(
+      mapBudgetInsightAccount(budgetInsightAccounts, aggregatorService, budgetInsightConnections, ownerInfo),
+    ).toEqual(expectedConnections);
   });
 
   it('should map the budget insight connections to analysis (no owner, no connector)', () => {
@@ -322,6 +332,9 @@ describe('BudgetInsightUtils', () => {
             },
           },
         ],
+        connector: {
+          logoUrl: undefined,
+        },
       },
       {
         id: 32,
@@ -355,12 +368,15 @@ describe('BudgetInsightUtils', () => {
             company_name: 'mockCompanyName',
           },
         ],
+        connector: {
+          logoUrl: undefined,
+        },
       },
     ];
 
-    expect(mapBudgetInsightAccount(budgetInsightAccounts, budgetInsightConnections, ownerInfo)).toEqual(
-      expectedConnections,
-    );
+    expect(
+      mapBudgetInsightAccount(budgetInsightAccounts, aggregatorService, budgetInsightConnections, ownerInfo),
+    ).toEqual(expectedConnections);
   });
 
   it('should map the budget insight transactions to analysis', async () => {

--- a/src/aggregator/services/budget-insight/budget-insight.utils.ts
+++ b/src/aggregator/services/budget-insight/budget-insight.utils.ts
@@ -20,15 +20,19 @@ import {
  */
 export const mapBudgetInsightAccount = (
   accounts: BudgetInsightAccount[],
+  aggregator: AggregatorService,
   connections?: Connection[],
   connectionsInfo?: { [key: string]: BudgetInsightOwner },
+  clientConfig?: ClientConfig,
 ): EnrichedConnection[] =>
   accounts.map((acc: BudgetInsightAccount): EnrichedConnection => {
     const connection: Connection | undefined = connections?.find((con) => con.id === acc.id_connection);
     const information: BudgetInsightOwner | undefined = get(connectionsInfo, `${connection?.id}`);
+    const logoUrl: string | undefined = aggregator.getBankLogoUrl(connection, clientConfig);
 
     return {
       ...connection,
+      connector: { ...connection?.connector, logoUrl },
       accounts: [acc],
       information,
     };

--- a/src/hooks/services/hooks.service.spec.ts
+++ b/src/hooks/services/hooks.service.spec.ts
@@ -609,6 +609,10 @@ describe('HooksService', () => {
                 ],
               },
             ],
+            connector: {
+              logoUrl: undefined,
+            },
+            information: undefined,
           },
         ],
         format: 'BUDGET_INSIGHT_V2_0',
@@ -719,6 +723,10 @@ describe('HooksService', () => {
                 ],
               },
             ],
+            connector: {
+              logoUrl: undefined,
+            },
+            information: undefined,
           },
         ],
         format: 'BUDGET_INSIGHT_V2_0',
@@ -841,6 +849,10 @@ describe('HooksService', () => {
                 ],
               },
             ],
+            connector: {
+              logoUrl: undefined,
+            },
+            information: undefined,
           },
         ],
         format: 'BUDGET_INSIGHT_V2_0',
@@ -964,6 +976,10 @@ describe('HooksService', () => {
                 ],
               },
             ],
+            connector: {
+              logoUrl: undefined,
+            },
+            information: undefined,
           },
         ],
         format: 'BUDGET_INSIGHT_V2_0',
@@ -1083,6 +1099,10 @@ describe('HooksService', () => {
                 ],
               },
             ],
+            connector: {
+              logoUrl: undefined,
+            },
+            information: undefined,
           },
           {
             accounts: [
@@ -1127,6 +1147,10 @@ describe('HooksService', () => {
                 ],
               },
             ],
+            connector: {
+              logoUrl: undefined,
+            },
+            information: undefined,
           },
         ],
         format: 'BUDGET_INSIGHT_V2_0',
@@ -1246,6 +1270,10 @@ describe('HooksService', () => {
                 ],
               },
             ],
+            connector: {
+              logoUrl: undefined,
+            },
+            information: undefined,
           },
         ],
         format: 'BUDGET_INSIGHT_V2_0',
@@ -1365,6 +1393,10 @@ describe('HooksService', () => {
                 ],
               },
             ],
+            connector: {
+              logoUrl: undefined,
+            },
+            information: undefined,
           },
         ],
         format: 'BUDGET_INSIGHT_V2_0',

--- a/src/hooks/services/hooks.service.ts
+++ b/src/hooks/services/hooks.service.ts
@@ -484,8 +484,10 @@ export class HooksService {
 
     const enrichedConnections: EnrichedConnection[] = mapBudgetInsightAccount(
       uniqueAccounts,
+      this.aggregator,
       connections,
       connectionsInfo,
+      serviceAccountConfig,
     );
 
     /**


### PR DESCRIPTION
### Documentation

I involuntarily removed the aggregation of the `logoUrl` in the PR to use the `format` API. 

#### References

- https://github.com/algoan/nestjs-budget-insight-connector/pull/392/