### PR TITLE
[NO-3883] add account ownerships to PATCH /analyses/:id body

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -17,7 +17,8 @@
     "waitingTime": 1000,
     "apiVersion": "2.0",
     "ignoredConnectionStates": ["wrongpass", "bug", "passwordExpired", "websiteUnavailable"],
-    "paginationLimit": 20
+    "paginationLimit": 20,
+    "enableAccountOwnerships": false
   },
   "targetUrl": "http://localhost:8080/hooks",
   "eventList": [

--- a/src/aggregator/interfaces/budget-insight-mock.ts
+++ b/src/aggregator/interfaces/budget-insight-mock.ts
@@ -1,4 +1,6 @@
 import {
+  AccountOwnership,
+  AccountPartyRole,
   AccountType,
   BankAccountOwnership,
   BankAccountUsage,
@@ -57,3 +59,24 @@ export const mockCategory: BudgetInsightCategory = {
   refundable: false,
   id_logo: 20,
 };
+
+export const mockAccountOwnerships: AccountOwnership[] = [
+  {
+    id_account: 351,
+    id_connection: 1,
+    id_user: 0,
+    id_connector_source: 0,
+    name: 'Saving account 01',
+    usage: BankAccountUsage.PRIVATE,
+    identifications: null,
+    parties: [
+      {
+        role: AccountPartyRole.HOLDER,
+        identity: {
+          is_user: true,
+          full_name: 'Jean Pierre',
+        },
+      },
+    ],
+  },
+];

--- a/src/aggregator/interfaces/budget-insight.interface.ts
+++ b/src/aggregator/interfaces/budget-insight.interface.ts
@@ -299,3 +299,65 @@ export interface User {
   signin: Date | string;
   platform: string;
 }
+
+/**
+ * Response of GET account ownerships
+ * https://docs.powens.com/api-reference/products/data-aggregation/account-ownerships#list-account-ownerships
+ */
+export interface AccountOwnership {
+  id_account: number;
+  id_connection: number;
+  id_user: number;
+  id_connector_source: number;
+  name: string | null;
+  usage: BankAccountUsage | null;
+  identifications: Identification[] | null;
+  parties: Party[] | null;
+}
+
+/**
+ * AccountSchemaName enum
+ */
+export enum AccountSchemeName {
+  IBAN = 'iban',
+  BBAN = 'bban',
+  SORT_CODE_ACCOUNT_NUMBER = 'sort_code_account_number',
+}
+
+/**
+ * Ownership's identification
+ */
+export interface Identification {
+  scheme_name: AccountSchemeName;
+  identification: string;
+}
+
+/**
+ * AccountPartyRole enum
+ */
+export enum AccountPartyRole {
+  HOLDER = 'holder',
+  CO_HOLDER = 'co_holder',
+  ATTORNEY = 'attorney',
+  CUSTODIAN_FOR_MINOR = 'custodian_for_minor',
+  LEGAL_GUARDIAN = 'legal_guardian',
+  NOMINEE = 'nominee',
+  SUCCESSOR_ON_DEATH = 'successor_on_death',
+  TRUSTEE = 'trustee',
+}
+
+/**
+ * Account ownership party
+ */
+export interface Party {
+  role: AccountPartyRole;
+  identity: IdentityParty;
+}
+
+/**
+ * Identity party
+ */
+export interface IdentityParty {
+  is_user: boolean | null;
+  full_name: string;
+}

--- a/src/aggregator/services/aggregator.service.spec.ts
+++ b/src/aggregator/services/aggregator.service.spec.ts
@@ -3,7 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { AlgoanModule } from '../../algoan/algoan.module';
 import { AppModule } from '../../app.module';
 import { Connection } from '../interfaces/budget-insight.interface';
-import { mockAccount, mockTransaction, mockCategory } from '../interfaces/budget-insight-mock';
+import { mockAccount, mockTransaction, mockCategory, mockAccountOwnerships } from '../interfaces/budget-insight-mock';
 import { AggregatorService } from './aggregator.service';
 import { BudgetInsightClient, ClientConfig } from './budget-insight/budget-insight.client';
 
@@ -153,5 +153,13 @@ describe('AggregatorService', () => {
     await service.getCategory(token, categoryId);
 
     expect(spy).toBeCalledWith(token, categoryId, undefined);
+  });
+
+  it('should get the account ownerships', async () => {
+    const spy = jest.spyOn(client, 'fetchAccountOwnerships').mockReturnValue(Promise.resolve(mockAccountOwnerships));
+    const token = 'token';
+    await service.getAccountOwnerships(token);
+
+    expect(spy).toBeCalledWith(token, undefined);
   });
 });

--- a/src/aggregator/services/aggregator.service.ts
+++ b/src/aggregator/services/aggregator.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import {
+  AccountOwnership,
   BudgetInsightAccount,
   BudgetInsightCategory,
   BudgetInsightOwner,
@@ -119,6 +120,15 @@ export class AggregatorService {
     clientConfig?: ClientConfig,
   ): Promise<BudgetInsightCategory> {
     return this.budgetInsightClient.fetchCategory(token, categoryId, clientConfig);
+  }
+
+  /**
+   * Get account ownerships
+   * @param token
+   * @param clientConfig
+   */
+  public async getAccountOwnerships(token: string, clientConfig?: ClientConfig): Promise<AccountOwnership[]> {
+    return this.budgetInsightClient.fetchAccountOwnerships(token, clientConfig);
   }
 
   /**

--- a/src/aggregator/services/budget-insight/budget-insight.client.spec.ts
+++ b/src/aggregator/services/budget-insight/budget-insight.client.spec.ts
@@ -14,7 +14,12 @@ import {
   AccountWrapper,
   ConnectionWrapper,
 } from '../../interfaces/budget-insight.interface';
-import { mockAccount, mockTransaction, mockCategory } from '../../interfaces/budget-insight-mock';
+import {
+  mockAccount,
+  mockTransaction,
+  mockCategory,
+  mockAccountOwnerships,
+} from '../../interfaces/budget-insight-mock';
 import { ClientConfig } from './budget-insight.client';
 import { config } from 'node-config-ts';
 
@@ -347,6 +352,22 @@ describe('BudgetInsightClient', () => {
       headers: {
         ...headers.headers,
         Authorization: `Bearer ${permanentToken}`,
+      },
+    });
+  });
+
+  it('should get the account ownerships', async () => {
+    result.data = mockAccountOwnerships;
+    const token = 'token';
+    const spy = jest.spyOn(httpService, 'get').mockImplementationOnce(() => of(result));
+
+    const ownerships = await service.fetchAccountOwnerships(token);
+
+    expect(ownerships).toEqual(mockAccountOwnerships);
+    expect(spy).toHaveBeenCalledWith('https://fake-budget-insights.com/2.0/users/me/account_ownerships', {
+      headers: {
+        ...headers.headers,
+        Authorization: `Bearer ${token}`,
       },
     });
   });

--- a/src/aggregator/services/budget-insight/budget-insight.client.ts
+++ b/src/aggregator/services/budget-insight/budget-insight.client.ts
@@ -21,6 +21,7 @@ import {
   BudgetInsightOwner,
   AccessTokenResponse,
   AuthJWTokenResponse,
+  AccountOwnership,
 } from '../../interfaces/budget-insight.interface';
 const DEFAULT_NUMBER_OF_MONTHS: number = 5;
 /**
@@ -331,6 +332,22 @@ export class BudgetInsightClient {
     );
 
     return resp.data;
+  }
+
+  /**
+   * Fetch the account ownerships
+   * https://docs.powens.com/api-reference/products/data-aggregation/account-ownerships#list-account-ownerships
+   * @param token the user token
+   * @param clientConfig the client config
+   */
+  public async fetchAccountOwnerships(token: string, clientConfig?: ClientConfig): Promise<AccountOwnership[]> {
+    const baseUrl: string = this.getClientConfig(clientConfig).baseUrl;
+    const url: string = `${baseUrl}/users/me/account_ownerships`;
+    const response: AxiosResponse<AccountOwnership[]> = await this.toPromise(
+      this.httpService.get(url, this.setHeaders(token)),
+    );
+
+    return response.data;
   }
 
   /**

--- a/src/algoan/dto/analysis.inputs.ts
+++ b/src/algoan/dto/analysis.inputs.ts
@@ -1,12 +1,6 @@
 import { EnrichedConnection } from '../../aggregator/interfaces/enriched-budget-insight.interface';
-import {
-  AccountType,
-  AccountUsage,
-  AccountSavingType,
-  AccountLoanType,
-  AnalysisStatus,
-  AccountOwnership,
-} from './analysis.enum';
+import { AccountOwnership } from '../../aggregator/interfaces/budget-insight.interface';
+import { AccountType, AccountUsage, AccountSavingType, AccountLoanType, AnalysisStatus } from './analysis.enum';
 import { AnalysisError } from './analysis.objects';
 
 /**
@@ -19,6 +13,7 @@ export type AnalysisUpdateInput =
     }
   | {
       connections?: EnrichedConnection[];
+      accountOwnerships?: AccountOwnership[];
       format: 'BUDGET_INSIGHT_V2_0';
     }
   | {

--- a/src/hooks/services/hooks.service.spec.ts
+++ b/src/hooks/services/hooks.service.spec.ts
@@ -648,6 +648,9 @@ describe('HooksService', () => {
       const userInfoSpy = jest.spyOn(aggregatorService, 'getInfo').mockResolvedValue({ owner: { name: 'JOHN DOE' } });
       const transactionSpy = jest.spyOn(aggregatorService, 'getTransactions').mockResolvedValue([mockTransaction]);
       const categorySpy = jest.spyOn(aggregatorService, 'getCategory').mockResolvedValue(mockCategory);
+      const accountOwnershipsSpy = jest
+        .spyOn(aggregatorService, 'getAccountOwnerships')
+        .mockResolvedValue(mockAccountOwnerships);
       const analysisSpy = jest
         .spyOn(algoanAnalysisService, 'updateAnalysis')
         .mockReturnValue(Promise.resolve({} as unknown as Analysis));
@@ -684,6 +687,7 @@ describe('HooksService', () => {
       expect(userInfoSpy).toBeCalledTimes(1);
       expect(transactionSpy).toBeCalledWith('fakeToken', 1, saConfig);
       expect(categorySpy).toBeCalledWith('fakeToken', mockTransaction.id_category, saConfig);
+      expect(accountOwnershipsSpy).toBeCalledTimes(0);
       expect(analysisSpy).toBeCalledWith('mockCustomerId', 'mockAnalysisId', {
         connections: [
           {
@@ -750,24 +754,25 @@ describe('HooksService', () => {
       } as unknown as Subscription;
 
       const spyGetCustomer = jest.spyOn(algoanCustomerService, 'getCustomerById').mockReturnValue(
-          Promise.resolve({
-            id: 'mockCustomerId',
-            aggregationDetails: { mode: AggregationDetailsMode.API, token: 'fakeToken' },
-          } as unknown as Customer),
+        Promise.resolve({
+          id: 'mockCustomerId',
+          aggregationDetails: { mode: AggregationDetailsMode.API, token: 'fakeToken' },
+        } as unknown as Customer),
       );
 
       const connectionSpy = jest
-          .spyOn(aggregatorService, 'getConnections')
-          .mockReturnValue(Promise.resolve([{ ...connection, state: ConnectionErrorState.WRONGPASS }]));
+        .spyOn(aggregatorService, 'getConnections')
+        .mockReturnValue(Promise.resolve([{ ...connection, state: ConnectionErrorState.WRONGPASS }]));
       const accountSpy = jest.spyOn(aggregatorService, 'getAccounts').mockResolvedValue([mockAccount]);
+      const userInfoSpy = jest.spyOn(aggregatorService, 'getInfo').mockResolvedValue({ owner: { name: 'JOHN DOE' } });
       const transactionSpy = jest.spyOn(aggregatorService, 'getTransactions').mockResolvedValue([mockTransaction]);
       const categorySpy = jest.spyOn(aggregatorService, 'getCategory').mockResolvedValue(mockCategory);
       const accountOwnershipsSpy = jest
-          .spyOn(aggregatorService, 'getAccountOwnerships')
-          .mockResolvedValue(mockAccountOwnerships);
+        .spyOn(aggregatorService, 'getAccountOwnerships')
+        .mockResolvedValue(mockAccountOwnerships);
       const analysisSpy = jest
-          .spyOn(algoanAnalysisService, 'updateAnalysis')
-          .mockReturnValue(Promise.resolve({} as unknown as Analysis));
+        .spyOn(algoanAnalysisService, 'updateAnalysis')
+        .mockReturnValue(Promise.resolve({} as unknown as Analysis));
 
       const event: EventDTO = {
         ...mockEvent,
@@ -797,6 +802,7 @@ describe('HooksService', () => {
       expect(spyGetCustomer).toBeCalledWith('mockCustomerId');
       expect(connectionSpy).toBeCalledWith('fakeToken', saConfig);
       expect(accountSpy).toBeCalledWith('fakeToken', saConfig);
+      expect(userInfoSpy).toBeCalledTimes(0);
       expect(transactionSpy).toBeCalledWith('fakeToken', 1, saConfig);
       expect(categorySpy).toBeCalledWith('fakeToken', mockTransaction.id_category, saConfig);
       expect(accountOwnershipsSpy).toBeCalledWith('fakeToken', saConfig);
@@ -856,7 +862,6 @@ describe('HooksService', () => {
       });
 
       config.budgetInsight.enableAccountOwnerships = false;
-
     });
 
     it('should fetch bank details if there is at least a finished connection with a warning (after timeout)', async () => {

--- a/src/hooks/services/hooks.service.spec.ts
+++ b/src/hooks/services/hooks.service.spec.ts
@@ -9,7 +9,13 @@ import { AggregationDetailsMode } from '../../algoan/dto/customer.enums';
 import { Customer } from '../../algoan/dto/customer.objects';
 import { Analysis } from '../../algoan/dto/analysis.objects';
 import { AggregatorModule } from '../../aggregator/aggregator.module';
-import { mockAccount, mockTransaction, mockCategory } from '../../aggregator/interfaces/budget-insight-mock';
+import { config } from 'node-config-ts';
+import {
+  mockAccount,
+  mockTransaction,
+  mockCategory,
+  mockAccountOwnerships,
+} from '../../aggregator/interfaces/budget-insight-mock';
 import { Connection, ConnectionErrorState } from '../../aggregator/interfaces/budget-insight.interface';
 import { AggregatorService } from '../../aggregator/services/aggregator.service';
 import { AlgoanModule } from '../../algoan/algoan.module';
@@ -731,6 +737,126 @@ describe('HooksService', () => {
         ],
         format: 'BUDGET_INSIGHT_V2_0',
       });
+    });
+
+    it('should fetch bank details - account ownerships enabled', async () => {
+      config.budgetInsight.enableAccountOwnerships = true;
+      const mockSubscription: Subscription = {
+        event: (_id: string) => ({
+          update: async ({ status }) => {
+            expect(status).toEqual('PROCESSED');
+          },
+        }),
+      } as unknown as Subscription;
+
+      const spyGetCustomer = jest.spyOn(algoanCustomerService, 'getCustomerById').mockReturnValue(
+          Promise.resolve({
+            id: 'mockCustomerId',
+            aggregationDetails: { mode: AggregationDetailsMode.API, token: 'fakeToken' },
+          } as unknown as Customer),
+      );
+
+      const connectionSpy = jest
+          .spyOn(aggregatorService, 'getConnections')
+          .mockReturnValue(Promise.resolve([{ ...connection, state: ConnectionErrorState.WRONGPASS }]));
+      const accountSpy = jest.spyOn(aggregatorService, 'getAccounts').mockResolvedValue([mockAccount]);
+      const transactionSpy = jest.spyOn(aggregatorService, 'getTransactions').mockResolvedValue([mockTransaction]);
+      const categorySpy = jest.spyOn(aggregatorService, 'getCategory').mockResolvedValue(mockCategory);
+      const accountOwnershipsSpy = jest
+          .spyOn(aggregatorService, 'getAccountOwnerships')
+          .mockResolvedValue(mockAccountOwnerships);
+      const analysisSpy = jest
+          .spyOn(algoanAnalysisService, 'updateAnalysis')
+          .mockReturnValue(Promise.resolve({} as unknown as Analysis));
+
+      const event: EventDTO = {
+        ...mockEvent,
+        subscription: {
+          ...mockEvent,
+          eventName: EventName.BANK_DETAILS_REQUIRED,
+        },
+        payload: { customerId: 'mockCustomerId', analysisId: 'mockAnalysisId', temporaryCode: 'mockTempCode' },
+      } as unknown as EventDTO;
+
+      const fakeServiceAccount: ServiceAccount = {
+        ...mockServiceAccount,
+        config: {
+          baseUrl: 'https://fake-base-url.url',
+          clientId: 'fakeClientId',
+        },
+      } as ServiceAccount;
+
+      await hooksService.dispatchAndHandleWebhook(event, mockSubscription, fakeServiceAccount, new Date());
+
+      const saConfig = {
+        baseUrl: 'https://fake-base-url.url',
+        clientId: 'fakeClientId',
+      };
+
+      expect(spyHttpService).toBeCalled();
+      expect(spyGetCustomer).toBeCalledWith('mockCustomerId');
+      expect(connectionSpy).toBeCalledWith('fakeToken', saConfig);
+      expect(accountSpy).toBeCalledWith('fakeToken', saConfig);
+      expect(transactionSpy).toBeCalledWith('fakeToken', 1, saConfig);
+      expect(categorySpy).toBeCalledWith('fakeToken', mockTransaction.id_category, saConfig);
+      expect(accountOwnershipsSpy).toBeCalledWith('fakeToken', saConfig);
+      expect(analysisSpy).toBeCalledWith('mockCustomerId', 'mockAnalysisId', {
+        connections: [
+          {
+            accounts: [
+              {
+                id: 1,
+                id_connection: 2,
+                id_user: 3,
+                id_source: 4,
+                id_parent: 5,
+                number: 'mockNumber',
+                original_name: 'mockOrginalName',
+                coming: 0,
+                currency: { id: 'id1' },
+                balance: 100,
+                name: 'mockName',
+                last_update: '2011-10-05T14:48:00.000Z',
+                type: 'checking',
+                iban: 'mockIban',
+                bic: 'mockBic',
+                disabled: false,
+                company_name: 'mockCompany',
+                usage: 'PRIV',
+                ownership: 'owner',
+                transactions: [
+                  {
+                    id_account: 5,
+                    id: 'mockId',
+                    application_date: 'mockApplicationDate',
+                    date: 'mockDate',
+                    rdate: 'mockRDate',
+                    simplified_wording: 'mockSimplifiedWording',
+                    value: 50,
+                    card: 'mockCard',
+                    wording: 'mockWording',
+                    id_category: 10,
+                    type: 'bank',
+                    original_wording: 'mockOriginalWording',
+                    original_currency: { id: 'USD' },
+                    coming: false,
+                    category: { name: 'mockCategoryName' },
+                  },
+                ],
+              },
+            ],
+            connector: {
+              logoUrl: undefined,
+            },
+            information: undefined,
+          },
+        ],
+        accountOwnerships: mockAccountOwnerships,
+        format: 'BUDGET_INSIGHT_V2_0',
+      });
+
+      config.budgetInsight.enableAccountOwnerships = false;
+
     });
 
     it('should fetch bank details if there is at least a finished connection with a warning (after timeout)', async () => {

--- a/src/hooks/services/hooks.service.ts
+++ b/src/hooks/services/hooks.service.ts
@@ -495,24 +495,11 @@ export class HooksService {
     /**
      * 3.b. Get personal information from every connection
      */
-    const connectionsInfo: { [key: string]: BudgetInsightOwner } = {};
-    if (!this.config.budgetInsight.enableAccountOwnerships) {
-      for (const connection of connections) {
-        try {
-          connectionsInfo[connection.id] = await this.aggregator.getInfo(
-            permanentToken,
-            `${connection.id}`,
-            serviceAccountConfig,
-          );
-        } catch (err) {
-          this.logger.warn({
-            message: `Unable to get user personal information`,
-            error: err,
-            connection,
-          });
-        }
-      }
-    }
+    const connectionsInfo: { [key: string]: BudgetInsightOwner } = await this.getConnectionsInfo(
+      connections,
+      permanentToken,
+      serviceAccountConfig,
+    );
 
     const enrichedConnections: EnrichedConnection[] = mapBudgetInsightAccount(
       accounts,
@@ -544,6 +531,36 @@ export class HooksService {
     }
 
     return enrichedConnections;
+  }
+
+  /**
+   * Get personal information from every connection
+   * @param connections
+   * @param token
+   * @param clientConfig
+   * @private
+   */
+  private async getConnectionsInfo(
+    connections: Connection[],
+    token: string,
+    clientConfig?: ClientConfig,
+  ): Promise<{ [key: string]: BudgetInsightOwner }> {
+    const connectionsInfo: { [key: string]: BudgetInsightOwner } = {};
+    if (!this.config.budgetInsight.enableAccountOwnerships) {
+      for (const connection of connections) {
+        try {
+          connectionsInfo[connection.id] = await this.aggregator.getInfo(token, `${connection.id}`, clientConfig);
+        } catch (err) {
+          this.logger.warn({
+            message: `Unable to get user personal information`,
+            error: err,
+            connection,
+          });
+        }
+      }
+    }
+
+    return connectionsInfo;
   }
 
   /**

--- a/src/hooks/services/hooks.service.ts
+++ b/src/hooks/services/hooks.service.ts
@@ -12,6 +12,7 @@ import { isEmpty } from 'lodash';
 import * as moment from 'moment';
 import { Config } from 'node-config-ts';
 import {
+  AccountOwnership,
   BudgetInsightAccount,
   BudgetInsightOwner,
   BudgetInsightTransaction,
@@ -39,7 +40,6 @@ import {
   EventDTO,
   ServiceAccountCreatedDTO,
   ServiceAccountUpdatedDTO,
-  SubscriptionDTO,
 } from '../dto';
 import { joinUserId } from '../helpers/join-user-id.helpers';
 import { EventName } from '../enums/event-name.enum';
@@ -316,6 +316,11 @@ export class HooksService {
         return;
       }
 
+      const accountOwnerships: AccountOwnership[] = await this.aggregator.getAccountOwnerships(
+        permanentToken,
+        serviceAccount.config as ClientConfig,
+      );
+
       const aggregationDuration: number = new Date().getTime() - aggregationStartDate.getTime();
 
       this.logger.log({
@@ -329,6 +334,7 @@ export class HooksService {
        */
       await this.algoanAnalysisService.updateAnalysis(payload.customerId, payload.analysisId, {
         connections: enrichedConnections,
+        accountOwnerships,
         format: 'BUDGET_INSIGHT_V2_0',
       });
       this.logger.debug({


### PR DESCRIPTION
# Documentation
This pull request aims to:
- fetch account ownerships from [Powens API](https://docs.powens.com/api-reference/products/data-aggregation/account-ownerships)
- add account ownerships to PATCH /analyses/:id body

# Note
[8c597ec](https://github.com/algoan/nestjs-budget-insight-connector/pull/412/commits/8c597ec30980c44579a4c646e736bf15e1fc671e): when account ownerships is enabled we don't fetch the connections information. Powens does not allow using both products at the same time.
