### PR TITLE
refactor(aggregator): modify response type of GET /accounts_ownerships

### DIFF
--- a/src/aggregator/services/budget-insight/budget-insight.client.spec.ts
+++ b/src/aggregator/services/budget-insight/budget-insight.client.spec.ts
@@ -357,7 +357,7 @@ describe('BudgetInsightClient', () => {
   });
 
   it('should get the account ownerships', async () => {
-    result.data = mockAccountOwnerships;
+    result.data = { account_ownerships: mockAccountOwnerships };
     const token = 'token';
     const spy = jest.spyOn(httpService, 'get').mockImplementationOnce(() => of(result));
 

--- a/src/aggregator/services/budget-insight/budget-insight.client.ts
+++ b/src/aggregator/services/budget-insight/budget-insight.client.ts
@@ -343,11 +343,11 @@ export class BudgetInsightClient {
   public async fetchAccountOwnerships(token: string, clientConfig?: ClientConfig): Promise<AccountOwnership[]> {
     const baseUrl: string = this.getClientConfig(clientConfig).baseUrl;
     const url: string = `${baseUrl}/users/me/account_ownerships`;
-    const response: AxiosResponse<AccountOwnership[]> = await this.toPromise(
+    const response: AxiosResponse<{ account_ownerships: AccountOwnership[] }> = await this.toPromise(
       this.httpService.get(url, this.setHeaders(token)),
     );
 
-    return response.data;
+    return response.data.account_ownerships;
   }
 
   /**


### PR DESCRIPTION
# Documentation
According to Powens documentation the endpoint returns an array of account ownerships but it is not the case. It returns an object:
```
{
  "accounts_ownerships": [...],
  "total": <number of resources>
}
```