### PR TITLE
[NO-3883] Modify enableAccountOwnerships scope

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -17,8 +17,7 @@
     "waitingTime": 1000,
     "apiVersion": "2.0",
     "ignoredConnectionStates": ["wrongpass", "bug", "passwordExpired", "websiteUnavailable"],
-    "paginationLimit": 20,
-    "enableAccountOwnerships": false
+    "paginationLimit": 20
   },
   "targetUrl": "http://localhost:8080/hooks",
   "eventList": [

--- a/src/aggregator/services/budget-insight/budget-insight.client.ts
+++ b/src/aggregator/services/budget-insight/budget-insight.client.ts
@@ -34,6 +34,7 @@ export interface ClientConfig {
   nbOfMonths?: number;
   language?: string;
   deleteUsers?: boolean;
+  enableAccountOwnerships?: boolean;
 }
 
 /**

--- a/src/hooks/services/hooks.service.spec.ts
+++ b/src/hooks/services/hooks.service.spec.ts
@@ -744,7 +744,6 @@ describe('HooksService', () => {
     });
 
     it('should fetch bank details - account ownerships enabled', async () => {
-      config.budgetInsight.enableAccountOwnerships = true;
       const mockSubscription: Subscription = {
         event: (_id: string) => ({
           update: async ({ status }) => {
@@ -788,6 +787,7 @@ describe('HooksService', () => {
         config: {
           baseUrl: 'https://fake-base-url.url',
           clientId: 'fakeClientId',
+          enableAccountOwnerships: true,
         },
       } as ServiceAccount;
 
@@ -796,6 +796,7 @@ describe('HooksService', () => {
       const saConfig = {
         baseUrl: 'https://fake-base-url.url',
         clientId: 'fakeClientId',
+        enableAccountOwnerships: true,
       };
 
       expect(spyHttpService).toBeCalled();
@@ -860,8 +861,6 @@ describe('HooksService', () => {
         accountOwnerships: mockAccountOwnerships,
         format: 'BUDGET_INSIGHT_V2_0',
       });
-
-      config.budgetInsight.enableAccountOwnerships = false;
     });
 
     it('should fetch bank details if there is at least a finished connection with a warning (after timeout)', async () => {

--- a/src/hooks/services/hooks.service.ts
+++ b/src/hooks/services/hooks.service.ts
@@ -380,7 +380,7 @@ export class HooksService {
     token: string,
     clientConfig: ClientConfig,
   ): Promise<AccountOwnership[] | undefined> {
-    if (!this.config.budgetInsight.enableAccountOwnerships) {
+    if (clientConfig.enableAccountOwnerships !== true) {
       return undefined;
     }
 
@@ -555,7 +555,7 @@ export class HooksService {
     clientConfig?: ClientConfig,
   ): Promise<{ [key: string]: BudgetInsightOwner }> {
     const connectionsInfo: { [key: string]: BudgetInsightOwner } = {};
-    if (!this.config.budgetInsight.enableAccountOwnerships) {
+    if (clientConfig?.enableAccountOwnerships !== true) {
       for (const connection of connections) {
         try {
           connectionsInfo[connection.id] = await this.aggregator.getInfo(token, `${connection.id}`, clientConfig);


### PR DESCRIPTION
# Documentation
This pull request aims to modify enableAccountOwnerships scope from global to project.
By default the account ownerships feature is not available/enabled on Powens API. Therefore we want to enable this feature only for project where it is available.